### PR TITLE
publish images only on master branch

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -67,6 +67,9 @@ pipeline {
         }
 
         stage('Publish') {
+            when {
+                branch 'master'
+            }
             steps {
                 withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
                     sh "docker push ${imageName}:bionic-curl"


### PR DESCRIPTION
this is a precursor to getting multiarch manifest support for buildpack-deps. it should only let images be published on the master branch.