### PR TITLE
set up multi-arch manifests for image builds

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -14,35 +14,185 @@ pipeline {
 
         stage('Build curl') {
             parallel {
-                stage('ubuntu:bionic') {
+                stage('ubuntu:bionic amd64') {
                     steps {
-                        sh "docker build -t bionic-curl:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic/curl"
-                        sh "docker tag bionic-curl:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic-curl"
+                        sh "docker build -t bionic-curl:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic/curl"
+                        sh "docker tag bionic-curl:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic-curl-amd64"
                     }
                 }
 
-                stage('ubuntu:xenial') {
+                stage('ubuntu:xenial amd64') {
                     steps {
-                        sh "docker build -t xenial-curl:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial/curl"
-                        sh "docker tag xenial-curl:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial-curl"
+                        sh "docker build -t xenial-curl:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial/curl"
+                        sh "docker tag xenial-curl:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial-curl-amd64"
+                    }
+                }
+
+                stage('ubuntu:bionic arm64') {
+                    agent {
+                        label 'arm64'
+                    }
+                    steps {
+                        sh "docker build -t bionic-curl:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic/curl"
+                        sh "docker tag bionic-curl:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic-curl-arm64"
+                    }
+                }
+
+                stage('ubuntu:xenial arm64') {
+                    agent {
+                        label 'arm64'
+                    }
+                    steps {
+                        sh "docker build -t xenial-curl:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial/curl"
+                        sh "docker tag xenial-curl:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial-curl-arm64"
                     }
                 }
             }
         }
 
-        stage('Build scm') {
+        stage('Publish curl Images') {
+            when {
+                branch 'master'
+            }
             parallel {
-                stage('ubuntu:bionic') {
+                stage('amd64') {
                     steps {
-                        sh "docker build -t bionic-scm:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic/scm"
-                        sh "docker tag bionic-scm:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic-scm"
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker push ${imageName}:bionic-curl-amd64"
+                            sh "docker push ${imageName}:xenial-curl-amd64"
+                        }
                     }
                 }
 
-                stage('ubuntu:xenial') {
+                stage('arm64') {
+                    agent {
+                        label 'arm64'
+                    }
                     steps {
-                        sh "docker build -t xenial-scm:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial/scm"
-                        sh "docker tag xenial-scm:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial-scm"
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker push ${imageName}:bionic-curl-arm64"
+                            sh "docker push ${imageName}:xenial-curl-arm64"
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Publish curl Manifests') {
+            when {
+                branch 'master'
+            }
+
+            parallel {
+                stage('bionic-curl') {
+                    steps {
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker manifest create --amend ${imageName}:bionic-curl ${imageName}:bionic-curl-amd64 ${imageName}:bionic-curl-arm64"
+                            sh "docker manifest push --purge ${imageName}:bionic-curl"
+                        }
+                    }
+                }
+
+                stage('xenial-curl') {
+                    steps {
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker manifest create --amend ${imageName}:xenial-curl ${imageName}:xenial-curl-amd64 ${imageName}:xenial-curl-arm64"
+                            sh "docker manifest push --purge ${imageName}:xenial-curl"
+                        }
+                    }
+                }
+            }
+        }
+
+
+
+        stage('Build scm') {
+            parallel {
+                stage('ubuntu:bionic amd64') {
+                    steps {
+                        sh "docker build -t bionic-scm:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic/scm"
+                        sh "docker tag bionic-scm:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic-scm-amd64"
+                    }
+                }
+
+                stage('ubuntu:xenial amd64') {
+                    steps {
+                        sh "docker build -t xenial-scm:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial/scm"
+                        sh "docker tag xenial-scm:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial-scm-amd64"
+                    }
+                }
+
+                stage('ubuntu:bionic arm64') {
+                    agent {
+                        label 'arm64'
+                    }
+                    steps {
+                        sh "docker build -t bionic-scm:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic/scm"
+                        sh "docker tag bionic-scm:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic-scm-arm64"
+                    }
+                }
+
+                stage('ubuntu:xenial arm64') {
+                    agent {
+                        label 'arm64'
+                    }
+                    steps {
+                        sh "docker build -t xenial-scm:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial/scm"
+                        sh "docker tag xenial-scm:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial-scm-arm64"
+                    }
+                }
+            }
+        }
+
+        stage('Publish scm Images') {
+            when {
+                branch 'master'
+            }
+            parallel {
+                stage('amd64') {
+                    steps {
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker push ${imageName}:bionic-scm-amd64"
+                            sh "docker push ${imageName}:xenial-scm-amd64"
+                        }
+                    }
+                }
+
+                stage('arm64') {
+                    agent {
+                        label 'arm64'
+                    }
+                    steps {
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker push ${imageName}:bionic-scm-arm64"
+                            sh "docker push ${imageName}:xenial-scm-arm64"
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Publish scm Manifests') {
+            when {
+                branch 'master'
+            }
+
+            parallel {
+                stage('bionic-scm') {
+                    steps {
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker manifest create --amend ${imageName}:bionic-scm ${imageName}:bionic-scm-amd64 ${imageName}:bionic-scm-arm64"
+                            sh "docker manifest push --purge ${imageName}:latest"
+                        }
+                    }
+                }
+
+                stage('xenial-scm') {
+                    steps {
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker manifest create --amend ${imageName}:xenial-scm ${imageName}:xenial-scm-amd64 ${imageName}:xenial-scm-arm64"
+                            sh "docker manifest push --purge ${imageName}:xenial-scm"
+                        }
                     }
                 }
             }
@@ -50,34 +200,92 @@ pipeline {
 
         stage('Build') {
             parallel {
-                stage('ubuntu:bionic') {
+                stage('ubuntu:bionic amd64') {
                     steps {
-                        sh "docker build -t bionic-bp:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic"
-                        sh "docker tag bionic-bp:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic"
+                        sh "docker build -t bionic-bp:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic"
+                        sh "docker tag bionic-bp:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic-amd64"
                     }
                 }
 
-                stage('ubuntu:xenial') {
+                stage('ubuntu:xenial amd64') {
                     steps {
-                        sh "docker build -t xenial-bp:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial"
-                        sh "docker tag xenial-bp:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial"
+                        sh "docker build -t xenial-bp:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial"
+                        sh "docker tag xenial-bp:amd64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial-amd64"
+                    }
+                }
+
+                stage('ubuntu:bionic arm64') {
+                    agent {
+                        label 'arm64'
+                    }
+                    steps {
+                        sh "docker build -t bionic-bp:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic"
+                        sh "docker tag bionic-bp:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic-arm64"
+                    }
+                }
+
+                stage('ubuntu:xenial arm64') {
+                    agent {
+                        label 'arm64'
+                    }
+                    steps {
+                        sh "docker build -t xenial-bp:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial"
+                        sh "docker tag xenial-bp:arm64.${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial-arm64"
                     }
                 }
             }
         }
 
-        stage('Publish') {
+        stage('Publish Images') {
             when {
                 branch 'master'
             }
-            steps {
-                withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
-                    sh "docker push ${imageName}:bionic-curl"
-                    sh "docker push ${imageName}:bionic-scm"
-                    sh "docker push ${imageName}:bionic"
-                    sh "docker push ${imageName}:xenial-curl"
-                    sh "docker push ${imageName}:xenial-scm"
-                    sh "docker push ${imageName}:xenial"
+            parallel {
+                stage('amd64') {
+                    steps {
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker push ${imageName}:bionic-amd64"
+                            sh "docker push ${imageName}:xenial-amd64"
+                        }
+                    }
+                }
+
+                stage('arm64') {
+                    agent {
+                        label 'arm64'
+                    }
+                    steps {
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker push ${imageName}:bionic-arm64"
+                            sh "docker push ${imageName}:xenial-arm64"
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Publish Manifests') {
+            when {
+                branch 'master'
+            }
+
+            parallel {
+                stage('bionic') {
+                    steps {
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker manifest create --amend ${imageName}:bionic ${imageName}:bionic-amd64 ${imageName}:bionic-arm64"
+                            sh "docker manifest push --purge ${imageName}:bionic"
+                        }
+                    }
+                }
+
+                stage('xenial') {
+                    steps {
+                        withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                            sh "docker manifest create --amend ${imageName}:xenial ${imageName}:xenial-amd64 ${imageName}:xenial-arm64"
+                            sh "docker manifest push --purge ${imageName}:xenial"
+                        }
+                    }
                 }
             }
         }

--- a/.jenkins
+++ b/.jenkins
@@ -1,0 +1,85 @@
+pipeline {
+
+    agent any
+
+    triggers {
+        upstream(upstreamProjects: 'vapor-ware/foundations/master', threshold: hudson.model.Result.SUCCESS)
+    }
+
+    environment {
+        imageName = 'vaporio/buildpack-deps'
+    }
+
+    stages {
+
+        stage('Build curl') {
+            parallel {
+                stage('ubuntu:bionic') {
+                    steps {
+                        sh "docker build -t bionic-curl:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic/curl"
+                        sh "docker tag bionic-curl:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic-curl"
+                    }
+                }
+
+                stage('ubuntu:xenial') {
+                    steps {
+                        sh "docker build -t xenial-curl:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial/curl"
+                        sh "docker tag xenial-curl:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial-curl"
+                    }
+                }
+            }
+        }
+
+        stage('Build scm') {
+            parallel {
+                stage('ubuntu:bionic') {
+                    steps {
+                        sh "docker build -t bionic-scm:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic/scm"
+                        sh "docker tag bionic-scm:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic-scm"
+                    }
+                }
+
+                stage('ubuntu:xenial') {
+                    steps {
+                        sh "docker build -t xenial-scm:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial/scm"
+                        sh "docker tag xenial-scm:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial-scm"
+                    }
+                }
+            }
+        }
+
+        stage('Build') {
+            parallel {
+                stage('ubuntu:bionic') {
+                    steps {
+                        sh "docker build -t bionic-bp:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress bionic"
+                        sh "docker tag bionic-bp:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:bionic"
+                    }
+                }
+
+                stage('ubuntu:xenial') {
+                    steps {
+                        sh "docker build -t xenial-bp:${env.BRANCH_NAME}.${env.BUILD_NUMBER} --compress xenial"
+                        sh "docker tag xenial-bp:${env.BRANCH_NAME}.${env.BUILD_NUMBER} ${imageName}:xenial"
+                    }
+                }
+            }
+        }
+
+        stage('Publish') {
+            when {
+                branch 'master'
+            }
+            steps {
+                withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
+                    sh "docker push ${imageName}:bionic-curl"
+                    sh "docker push ${imageName}:bionic-scm"
+                    sh "docker push ${imageName}:bionic"
+                    sh "docker push ${imageName}:xenial-curl"
+                    sh "docker push ${imageName}:xenial-scm"
+                    sh "docker push ${imageName}:xenial"
+                }
+            }
+        }
+    }
+}

--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bionic-scm
+FROM vaporio/buildpack-deps:bionic-scm
 
 RUN set -ex; \
 	apt-get update; \

--- a/bionic/curl/Dockerfile
+++ b/bionic/curl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM vaporio/foundation:bionic
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \

--- a/bionic/scm/Dockerfile
+++ b/bionic/scm/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bionic-curl
+FROM vaporio/buildpack-deps:bionic-curl
 
 # procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:xenial-scm
+FROM vaporio/buildpack-deps:xenial-scm
 
 RUN set -ex; \
 	apt-get update; \

--- a/xenial/curl/Dockerfile
+++ b/xenial/curl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM vaporio/foundation:xenial
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \

--- a/xenial/scm/Dockerfile
+++ b/xenial/scm/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:xenial-curl
+FROM vaporio/buildpack-deps:xenial-curl
 
 # procps is very common in build systems, and is a reasonably small package
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
there may be a cleaner/fancier way to do this by using maps, but I believe we'd need 'amd64' labels on nodes to make that happen. while verbose, this should do the trick.